### PR TITLE
フロントマターの tag / category を Hexo 標準の複数形に直す

### DIFF
--- a/hexiita.go
+++ b/hexiita.go
@@ -51,11 +51,11 @@ func (m HexoMeta) WriteHeader(w io.Writer) error {
 	_, _ = fmt.Fprintf(w, "title: %s\n", m.Title)
 	_, _ = fmt.Fprintf(w, "date: %s\n", m.Date)
 	_, _ = fmt.Fprintf(w, "postid: %s\n", m.PostID)
-	_, _ = fmt.Fprintf(w, "tag:\n")
+	_, _ = fmt.Fprintf(w, "tags:\n")
 	for _, tag := range m.Tags {
 		_, _ = fmt.Fprintf(w, "  - %s\n", tag)
 	}
-	_, _ = fmt.Fprintf(w, "category:\n")
+	_, _ = fmt.Fprintf(w, "categories:\n")
 	_, _ = fmt.Fprintf(w, "  - %s\n", m.Category)
 	_, _ = fmt.Fprintf(w, "thumbnail: %s\n", m.Thumbnail)
 	_, _ = fmt.Fprintf(w, "author: %s\n", m.Author)


### PR DESCRIPTION
`HexoMeta.WriteHeader()` が出力するフロントマターのキーが単数形の `tag:` / `category:` だったので、Hexo 標準の `tags:` / `categories:` に直す。

```diff
-	_, _ = fmt.Fprintf(w, "tag:\n")
+	_, _ = fmt.Fprintf(w, "tags:\n")
 	for _, tag := range m.Tags {
 		_, _ = fmt.Fprintf(w, "  - %s\n", tag)
 	}
-	_, _ = fmt.Fprintf(w, "category:\n")
+	_, _ = fmt.Fprintf(w, "categories:\n")
```

## 理由

単数形は Hexo が公式にサポートするエイリアスで、`hexo/dist/plugins/processor/post.js` が複数形へ正規化するため表示は壊れていない。ただし:

- 正規化の条件が `data.category && !data.categories` なので、**単数形と複数形の両方が書かれると単数形が黙って無視される**
- 未知のフロントマターキーは警告されないため、**タイポが検知できない**（出力先リポジトリで `ategory:` のタイポが5年以上カテゴリ未設定のまま公開されていた）
- 外部ツール・ドキュメント・生成AIは複数形を前提にすることが多い

## 出力先リポジトリとの歩調

先にこちらだけ直すと新規記事だけ複数形になって混在するため、出力先の [future-architect/future-architect.github.io](https://github.com/future-architect/future-architect.github.io) 側で既存1466記事を一括置換する PR とセットでマージしたい。

なお単数形・複数形のどちらでも Hexo は解釈できるので、マージ順が前後しても記事の表示は壊れない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)